### PR TITLE
- Fix for processing empty bundle

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,25 +31,25 @@ function createPlugin({
   return {
     name: "rollup-plugin-inline-js",
     renderChunk(code, {fileName}, {dir: outputDir, globals}) {
-      if (code) {
-        if (names && typeof names === "object" && !isNamesResolved) {
-          const output = {};
-          for (const [key, value] of Object.entries(names)) {
-            output[resolveId(key, outputDir)] = value;
-          }
-          names = output;
-          isNamesResolved = true;
-        }
-
-        return iifeTransform({
-          code,
-          parse: this.parse,
-          name: idToName(path.resolve(outputDir, fileName), [names, globals], prefix),
-          sourcemap,
-          resolveGlobal: id => idToName(resolveId(id, outputDir), [names, globals])
-        });
+      if (!code) {
+        return null;
       }
-      return null;
+      if (names && typeof names === "object" && !isNamesResolved) {
+        const output = {};
+        for (const [key, value] of Object.entries(names)) {
+          output[resolveId(key, outputDir)] = value;
+        }
+        names = output;
+        isNamesResolved = true;
+      }
+
+      return iifeTransform({
+        code,
+        parse: this.parse,
+        name: idToName(path.resolve(outputDir, fileName), [names, globals], prefix),
+        sourcemap,
+        resolveGlobal: id => idToName(resolveId(id, outputDir), [names, globals])
+      });
     }
   };
 

--- a/test/test.js
+++ b/test/test.js
@@ -290,7 +290,7 @@ describe("rollup-plugin-iife", () => {
     })
   );
 
-  it("multiple entries when some are empty", () =>
+  it("work with empty chunks", () =>
     withDir(`
       - entry.js: |
           import {foo} from "./foo.js";
@@ -317,6 +317,7 @@ describe("rollup-plugin-iife", () => {
         };
         })();
       `);
+      assert.equal(result.output["bar.js"].code.trim(), "");
     })
   );
 });


### PR DESCRIPTION
Other plugins allow specifying non-JavaScript files as entries and these generate empty bundles even if they aren't actually outputted, which breaks `rollup-plugin-iife`.
Added a simple check that `code` is not empty to `renderChunk` hook. 